### PR TITLE
Convert Room and Glide to use KSP instead of KAPT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.androidx.navigation.safeargs.kotlin) apply false
 }
 

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     id("odeon.android.library")
     id("odeon.android.hilt")
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -35,7 +36,7 @@ dependencies {
     implementation(libs.androidx.media)
     implementation(libs.identikon)
 
-    kapt(libs.glide.compiler)
+    ksp(libs.glide.ksp)
 
     testImplementation(projects.coreTest)
     testImplementation(libs.bundles.testing.unit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ identikon = "1.0.0"
 kotest = "5.7.2"
 kotlin = "1.8.22"
 kotlinx-coroutines = "1.7.3"
+ksp = "1.8.22-1.0.11"
 material = "1.9.0"
 mockk = "1.12.8"
 robolectric = "4.10.3"
@@ -39,6 +40,7 @@ androidx-navigation-safeargs-kotlin = { id = "androidx.navigation.safeargs.kotli
 dagger-hilt = { id = "dagger.hilt.android.plugin", version.ref = "dagger" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versions-plugin" }
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,7 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-viewpager = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager" }
 
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
-glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
+glide-ksp = { module = "com.github.bumptech.glide:ksp", version.ref = "glide" }
 
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "dagger" }


### PR DESCRIPTION
KAPT is officially in maintenance mode, and is meant to be replaced by KSP.
Note that Dagger/Hilt still use KAPT so it can't be removed yet. Build performance benefits won't be visible until KAPT has been totally removed.