### PR TITLE
Restrict usage of LiveData

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
     implementation(libs.bundles.core)
     implementation(libs.bundles.android.ui)
     implementation(libs.bundles.androidx.lifecycle)
+    implementation(libs.androidx.lifecycle.livedata)
     implementation(libs.androidx.viewpager)
     implementation(libs.androidx.media)
 

--- a/core-ui/src/main/java/fr/nihilus/music/core/ui/Event.kt
+++ b/core-ui/src/main/java/fr/nihilus/music/core/ui/Event.kt
@@ -16,11 +16,10 @@
 
 package fr.nihilus.music.core.ui
 
-import androidx.lifecycle.LiveData
 import com.google.android.material.snackbar.Snackbar
 
 /**
- * Encapsulate data that is exposed via [LiveData] to represent it as an event.
+ * Encapsulate state to represent it as an event.
  * This prevents observers from using the same data more than a single time,
  * such as the text of a [Snackbar] or the result of a background operation.
  *

--- a/core-ui/src/main/java/fr/nihilus/music/core/ui/UiStateFlows.kt
+++ b/core-ui/src/main/java/fr/nihilus/music/core/ui/UiStateFlows.kt
@@ -17,7 +17,6 @@
 package fr.nihilus.music.core.ui
 
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -50,7 +49,7 @@ fun <T> Flow<T>.uiStateIn(scope: CoroutineScope, initialState: T): StateFlow<T> 
 )
 
 /**
- * Helper function that collects a [StateFlow] the same way we observe [LiveData].
+ * Helper function that collects a [StateFlow] the same way we observe `LiveData`.
  */
 fun <T> StateFlow<T>.observe(owner: LifecycleOwner, observer: (value: T) -> Unit) {
     flowWithLifecycle(owner.lifecycle)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,7 +110,6 @@ android-ui = [
 ]
 androidx-lifecycle = [
     "androidx-lifecycle-runtime",
-    "androidx-lifecycle-livedata",
     "androidx-lifecycle-viewmodel",
     "androidx-lifecycle-java8",
     "androidx-lifecycle-process"

--- a/ui-cleanup/src/main/java/fr/nihilus/music/ui/cleanup/CleanupFragment.kt
+++ b/ui-cleanup/src/main/java/fr/nihilus/music/ui/cleanup/CleanupFragment.kt
@@ -34,6 +34,7 @@ import fr.nihilus.music.core.ui.ConfirmDialogFragment
 import fr.nihilus.music.core.ui.base.BaseFragment
 import fr.nihilus.music.core.ui.extensions.doOnApplyWindowInsets
 import fr.nihilus.music.core.ui.extensions.startActionMode
+import fr.nihilus.music.core.ui.observe
 import fr.nihilus.music.core.ui.view.DividerItemDecoration
 import fr.nihilus.music.media.tracks.DeleteTracksResult
 import fr.nihilus.music.ui.cleanup.databinding.FragmentCleanupBinding
@@ -102,7 +103,7 @@ internal class CleanupFragment : BaseFragment(R.layout.fragment_cleanup) {
 
 
         binding.deleteTracksButton.setOnClickListener {
-            val selectedCount = viewModel.state.value?.selectedCount ?: 0
+            val selectedCount = viewModel.state.value.selectedCount
             askCleanupConfirmation(selectedCount)
         }
 

--- a/ui-cleanup/src/main/java/fr/nihilus/music/ui/cleanup/CleanupViewModel.kt
+++ b/ui-cleanup/src/main/java/fr/nihilus/music/ui/cleanup/CleanupViewModel.kt
@@ -16,18 +16,18 @@
 
 package fr.nihilus.music.ui.cleanup
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import fr.nihilus.music.core.media.MediaId
 import fr.nihilus.music.core.media.MediaId.Builder.CATEGORY_ALL
 import fr.nihilus.music.core.media.MediaId.Builder.TYPE_TRACKS
 import fr.nihilus.music.core.ui.actions.DeleteTracksAction
+import fr.nihilus.music.core.ui.uiStateIn
 import fr.nihilus.music.media.tracks.DeleteTracksResult
 import fr.nihilus.music.media.usage.UsageManager
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -44,7 +44,7 @@ internal class CleanupViewModel @Inject constructor(
     private val pendingEvent = MutableStateFlow<DeleteTracksResult?>(null)
     private val selection = MutableStateFlow<Set<MediaId>>(emptySet())
 
-    val state: LiveData<CleanupState> = combine(
+    val state: StateFlow<CleanupState> = combine(
         usageManager.getDisposableTracks()
             .map { tracks ->
                 tracks.map {
@@ -75,7 +75,15 @@ internal class CleanupViewModel @Inject constructor(
             result = event
         )
     }
-        .asLiveData()
+        .uiStateIn(
+            viewModelScope,
+            initialState = CleanupState(
+                tracks = emptyList(),
+                selectedCount = 0,
+                selectedFreedBytes = 0,
+                result = null
+            )
+        )
 
     fun deleteSelected() {
         viewModelScope.launch {

--- a/ui-settings/src/main/java/fr/nihilus/music/ui/settings/exclusion/ExcludedTracksFragment.kt
+++ b/ui-settings/src/main/java/fr/nihilus/music/ui/settings/exclusion/ExcludedTracksFragment.kt
@@ -23,6 +23,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
 import fr.nihilus.music.core.ui.base.BaseFragment
+import fr.nihilus.music.core.ui.observe
 import fr.nihilus.music.core.ui.view.DividerItemDecoration
 import fr.nihilus.music.ui.settings.R
 import fr.nihilus.music.ui.settings.databinding.ExcludedTracksFragmentBinding

--- a/ui-settings/src/main/java/fr/nihilus/music/ui/settings/exclusion/ExcludedTracksViewModel.kt
+++ b/ui-settings/src/main/java/fr/nihilus/music/ui/settings/exclusion/ExcludedTracksViewModel.kt
@@ -16,12 +16,12 @@
 
 package fr.nihilus.music.ui.settings.exclusion
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fr.nihilus.music.core.ui.uiStateIn
 import fr.nihilus.music.media.tracks.TrackRepository
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -34,7 +34,7 @@ internal class ExcludedTracksViewModel @Inject constructor(
     /**
      * List of tracks that are excluded from the music library.
      */
-    val tracks: LiveData<List<ExcludedTrackUiState>> by lazy {
+    val tracks: StateFlow<List<ExcludedTrackUiState>> by lazy {
         repository.excludedTracks
             .map { tracks ->
                 tracks.map {
@@ -48,7 +48,7 @@ internal class ExcludedTracksViewModel @Inject constructor(
                     )
                 }
             }
-            .asLiveData()
+            .uiStateIn(viewModelScope, initialState = emptyList())
     }
 
     /**


### PR DESCRIPTION
Removes usages of LiveData from the following features:
- settings
- cleanup

LiveData is now only used in the app module, which still implements bad reactive patterns.