### PR TITLE
Target Android API 33 (Android 13)

### DIFF
--- a/app/src/main/kotlin/fr/nihilus/music/HomeActivity.kt
+++ b/app/src/main/kotlin/fr/nihilus/music/HomeActivity.kt
@@ -18,6 +18,7 @@ package fr.nihilus.music
 
 import android.Manifest
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -45,6 +46,13 @@ class HomeActivity : BaseActivity() {
 
     private val sheetCollapsingCallback = BottomSheetCollapsingCallback()
 
+    private val mediaPermissionName
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_AUDIO
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+
     private val requestReadPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { permissionGranted ->
@@ -60,7 +68,7 @@ class HomeActivity : BaseActivity() {
         if (!permissionGranted &&
             ActivityCompat.shouldShowRequestPermissionRationale(
                 this,
-                Manifest.permission.READ_EXTERNAL_STORAGE
+                mediaPermissionName
             )
         ) {
             ConfirmDialogFragment.open(
@@ -91,7 +99,7 @@ class HomeActivity : BaseActivity() {
         setContentView(binding.root)
 
         setupPlayerView()
-        requestReadPermission.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+        requestReadPermission.launch(mediaPermissionName)
     }
 
     override fun onResume() {

--- a/build-logic/src/main/kotlin/AndroidVersion.kt
+++ b/build-logic/src/main/kotlin/AndroidVersion.kt
@@ -16,6 +16,6 @@
 
 internal object AndroidVersion {
     const val COMPILE = 34
-    const val TARGET = 31
+    const val TARGET = 33
     const val MINIMUM = 24
 }

--- a/core/common/src/main/kotlin/fr/nihilus/music/core/permissions/PermissionRepository.kt
+++ b/core/common/src/main/kotlin/fr/nihilus/music/core/permissions/PermissionRepository.kt
@@ -19,6 +19,7 @@ package fr.nihilus.music.core.permissions
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -74,9 +75,17 @@ class PermissionRepository @Inject constructor(
     }
 
     private fun readPermissions() = RuntimePermission(
-        canReadAudioFiles = isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE),
+        canReadAudioFiles = hasReadMediaPermission(),
         canWriteAudioFiles = isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE),
     )
+
+    private fun hasReadMediaPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            isPermissionGranted(Manifest.permission.READ_MEDIA_AUDIO)
+        } else {
+            isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+    }
 
     private fun isPermissionGranted(permissionName: String): Boolean =
         ContextCompat.checkSelfPermission(

--- a/media/src/main/AndroidManifest.xml
+++ b/media/src/main/AndroidManifest.xml
@@ -17,7 +17,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29"

--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
 


### PR DESCRIPTION
Most notable changes:
- App requests new permission READM_MEDIA_AUDIO instead of READ_EXTERNAL_STORAGE (which is no longer supported).
- App won't require the POST_NOTIFICATIONS permission, as notifications bound to a media session are allowed without requiring the permission.