### PR TITLE
Fix dark text on dark background when dark mode is enabled

### DIFF
--- a/ui/settings/src/main/kotlin/fr/nihilus/music/ui/settings/exclusion/ExcludedTrackRow.kt
+++ b/ui/settings/src/main/kotlin/fr/nihilus/music/ui/settings/exclusion/ExcludedTrackRow.kt
@@ -71,6 +71,7 @@ private fun TrackRow(track: ExcludedTrackUiState, modifier: Modifier = Modifier)
             Text(
                 text = track.title,
                 style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )

--- a/ui/settings/src/main/kotlin/fr/nihilus/music/ui/settings/exclusion/ExcludedTracksScreen.kt
+++ b/ui/settings/src/main/kotlin/fr/nihilus/music/ui/settings/exclusion/ExcludedTracksScreen.kt
@@ -16,6 +16,7 @@
 
 package fr.nihilus.music.ui.settings.exclusion
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -25,9 +26,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -48,17 +51,19 @@ internal fun ExcludedTracksScreen(
 
 @Composable
 private fun FeatureNotice() {
-    Row {
-        Icon(
-            imageVector = Icons.Outlined.Info,
-            contentDescription = null,
-            modifier = Modifier.padding(16.dp)
-        )
-        Text(
-            text = stringResource(R.string.track_exclusion_feature_description),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(vertical = 16.dp)
-        )
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+        Row {
+            Icon(
+                imageVector = Icons.Outlined.Info,
+                contentDescription = null,
+                modifier = Modifier.padding(16.dp),
+            )
+            Text(
+                text = stringResource(R.string.track_exclusion_feature_description),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(vertical = 16.dp)
+            )
+        }
     }
 }
 
@@ -82,6 +87,7 @@ private fun TrackList(
 
 @Composable
 @Preview
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun Preview() {
     OdeonTheme {
         ExcludedTracksScreen(


### PR DESCRIPTION
It seems that the default text color is not properly set when not defined within a Surface composable.